### PR TITLE
Fixed dependencies in requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
 fitz
 pymupdf
-airflow
-logging
-google
-gc
-re
-json
+apache-airflow


### PR DESCRIPTION
Some of the dependencies in the requirements.txt file were redundant as they are python standard libraries. I've removed them and changed airflow to apache-airflow.